### PR TITLE
use raw github path

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,10 @@
     </section>
 
     <!-- updated path to work with GH pages -->
-    <audio id="prizeSound" src="/pokemonWin.mp3"></audio>
+    <audio
+      id="prizeSound"
+      src="https://github.com/fac-23/preA-week2-http-olimilly/blob/main/pokemonWin.mp3?raw=true"
+    ></audio>
 
     <script src="app.js"></script>
   </body>


### PR DESCRIPTION
Followed stack overflow workaround and referenced github pages raw file:
https://stackoverflow.com/questions/31353711/source-an-audio-file-in-repo-on-github-pages

"https://github.com/fac-23/preA-week2-http-olimilly/blob/main/pokemonWin.mp3?raw=true"

🤞🏽